### PR TITLE
docs: update README with correct Fedora zbar dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For a detailed installation documentation of [pyzbar](https://github.com/Natural
 
 #### Linux (Fedora)
 
-    sudo dnf install libzbar0
+    sudo dnf install zbar
 
 #### Linux (Arch Linux)
 


### PR DESCRIPTION
`zbar` is the available dependency: https://packages.fedoraproject.org/pkgs/zbar/zbar/