### PR TITLE
fix: disable Python 3.x in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.x", "3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         # exclude:
 


### PR DESCRIPTION
unit tests are failing in 3.x, but not 3.12 or 3.11