### PR TITLE
Enable Docker provenance and SBOM

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Build image (Bookworm/Debian 12) and push to Docker Hub and GitHub Container Registry"
         id: docker_build_qr_reader_latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.DOCKER_ARCH }}
           # relative path to the place where source code with Dockerfile is located
@@ -202,7 +202,7 @@ jobs:
 
       - name: "only_txt: Build image and push to Docker Hub and GitHub Container Registry"
         id: docker_build_only_txt
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.DOCKER_ARCH }}
           # relative path to the place where source code with Dockerfile is located
@@ -329,7 +329,7 @@ jobs:
       - name: "Build image from Bullseye (Debian 11) and push to GitHub Container Registry"
         id: docker_build_bullseye
         if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.DOCKER_ARCH }}
           # relative path to the place where source code with Dockerfile is located

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -95,6 +95,7 @@ jobs:
             docker.io/scit0/extract_otp_secrets:bookworm-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:latest-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:bookworm-${{ matrix.PLATFORM_ARCH }}
+          provenance: true
           # build on feature branches, push only on master branch
           push: ${{ github.ref == 'refs/heads/master' && github.secret_source == 'Actions'}}
 
@@ -216,6 +217,7 @@ jobs:
             docker.io/scit0/extract_otp_secrets:alpine-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:only-txt-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:alpine-${{ matrix.PLATFORM_ARCH }}
+          provenance: true
           # build on feature branches, push only on master branch
           push: ${{ github.ref == 'refs/heads/master' && github.secret_source == 'Actions'}}
           build-args: |
@@ -343,6 +345,7 @@ jobs:
           tags: |
             docker.io/scit0/extract_otp_secrets:bullseye-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:bullseye-${{ matrix.PLATFORM_ARCH }}
+          provenance: true
           push: ${{ github.secret_source == 'Actions' }}
 
       - name: Image digest

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -96,6 +96,7 @@ jobs:
             ghcr.io/scito/extract_otp_secrets:latest-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:bookworm-${{ matrix.PLATFORM_ARCH }}
           provenance: true
+          sbom: true
           # build on feature branches, push only on master branch
           push: ${{ github.ref == 'refs/heads/master' && github.secret_source == 'Actions'}}
 
@@ -218,6 +219,7 @@ jobs:
             ghcr.io/scito/extract_otp_secrets:only-txt-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:alpine-${{ matrix.PLATFORM_ARCH }}
           provenance: true
+          sbom: true
           # build on feature branches, push only on master branch
           push: ${{ github.ref == 'refs/heads/master' && github.secret_source == 'Actions'}}
           build-args: |
@@ -346,6 +348,7 @@ jobs:
             docker.io/scit0/extract_otp_secrets:bullseye-${{ matrix.PLATFORM_ARCH }}
             ghcr.io/scito/extract_otp_secrets:bullseye-${{ matrix.PLATFORM_ARCH }}
           provenance: true
+          sbom: true
           push: ${{ github.secret_source == 'Actions' }}
 
       - name: Image digest


### PR DESCRIPTION
Upgrade the Docker build action to version 6, enable provenance for Docker images, and add support for SBOM generation in the CI workflow.