### PR TITLE
fix(ci): make ci compatible with qrcode 3 and its dependencies

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -88,10 +88,16 @@ jobs:
             https://api.github.com/repos/scito/extract_otp_secrets/releases \
             --silent \
             --show-error \
-            -d '{"tag_name":"${{ github.ref }}","target_commitish":"master","name":"${{ steps.meta.outputs.version }} - ${{ steps.meta.outputs.date }}","body":"${{ steps.meta.outputs.tag_message }}\n\n## Executables\n\nDownload the executable for your platform and execute it, see [README.md](https://github.com/scito/extract_otp_secrets#readme)\n\n | Executable | Description |\n | --- | --- |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_linux_x86_64 | Linux x86_64/amd64 (glibc >= 2.31) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_linux_arm64 | Linux arm64 (glibc >= 2.31), huge binary (2.7GB) due to included dependencies |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_win_x86_64.exe | Windows x86_64/amd64/x64 |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_win_arm64.exe | N/A |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64 | MacOS arm64 (bare executable, see [README.md](https://github.com/scito/extract_otp_secrets#readme); optional libzbar must be installed manually, see [README.md](https://github.com/scito/extract_otp_secrets#readme)), huge binary (2.7GB) due to included dependencies |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_x86_64 | N/A |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64.dmg | N/A, see [README.md](https://github.com/scito/extract_otp_secrets#readme) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64.pkg | N/A, see [README.md](https://github.com/scito/extract_otp_secrets#readme) |\n","draft":true,"prerelease":false,"generate_release_notes":true}')
+            -d '{"tag_name":"${{ github.ref }}","target_commitish":"master","name":"${{ steps.meta.outputs.version }} - ${{ steps.meta.outputs.date }}","body":"## Executables\n\nDownload the executable for your platform and execute it, see [README.md](https://github.com/scito/extract_otp_secrets#readme)\n\n | Executable | Description |\n | --- | --- |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_linux_x86_64 | Linux x86_64/amd64 (glibc >= 2.31) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_linux_arm64 | Linux arm64 (glibc >= 2.31) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_win_x86_64.exe | Windows x86_64/amd64/x64 |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_win_arm64.exe | N/A |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64 | MacOS arm64 (bare executable, see [README.md](https://github.com/scito/extract_otp_secrets#readme); optional libzbar must be installed manually, see [README.md](https://github.com/scito/extract_otp_secrets#readme)) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_x86_64 | N/A |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64.dmg | N/A, see [README.md](https://github.com/scito/extract_otp_secrets#readme) |\n | extract_otp_secrets${{ steps.meta.outputs.inline_version }}_macos_arm64.pkg | N/A, see [README.md](https://github.com/scito/extract_otp_secrets#readme) |\n","draft":true,"prerelease":false,"generate_release_notes":true}')
+          release_id=$(jq -r '.id' <<< "$response")
+          if [ "$release_id" == "null" ] || [ -z "$release_id" ]; then
+            echo "::error::Failed to create release, no id in response:"
+            echo "$response"
+            exit 1
+          fi
           echo upload_url=$(jq '.upload_url' <<< "$response") >> $GITHUB_OUTPUT
           echo $(jq -r '.upload_url' <<< "$response") > release_url.txt
-          echo $(jq -r '.id' <<< "$response") > release_id.txt
+          echo "$release_id" > release_id.txt
       - name: Save Release URL File for publish
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v7
@@ -128,11 +134,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       # avoid building if there are testing errors
       - name: Run smoke test
         run: |
           sudo apt-get update
-          sudo apt-get install -y libzbar0
+          sudo apt-get install -y libzbar0 libgl1
           python -m pip install --upgrade pip
           pip install -U -r requirements-dev.txt
           pip install -U .
@@ -145,11 +163,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
-        # Workaround for failing builds: https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
-        # TODO remove workaround when fixed
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
 
       - name: Login to DockerHub
         uses: docker/login-action@v4
@@ -176,8 +189,18 @@ jobs:
         # https://hub.docker.com/r/multiarch/qemu-user-static/
       - name: Run Pyinstaller in container for ${{ matrix.EXE }}
         run: |
-          docker run --pull always --entrypoint /bin/bash --rm -v "$(pwd)":/files -w /files docker.io/scit0/extract_otp_secrets:bullseye -c 'apt-get update && apt-get -y install binutils && pip install -U -r /files/requirements.txt && pip install pyinstaller && PYTHONHASHSEED=31 && python -c "from qrdet import QRDetector; QRDetector()" && QRDET_MODEL_DIR=$(python -c "import qrdet, os; print(os.path.dirname(qrdet.__file__))" | tail -n 1)/.model && pyinstaller -y --add-data "$QRDET_MODEL_DIR:qrdet/.model" --onefile --name ${{ matrix.EXE }} --distpath /files/dist/ /files/src/extract_otp_secrets.py'
-
+          docker run --pull always --entrypoint /bin/bash --rm -v "$(pwd)":/files -w /files docker.io/scit0/extract_otp_secrets:bullseye -c 'apt-get update && apt-get -y install binutils && pip install --no-cache-dir -U -r /files/requirements.txt torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu && pip install pyinstaller && PYTHONHASHSEED=31 && python -c "from qrdet import QRDetector; QRDetector()" && QRDET_MODEL_DIR=$(python -c "import qrdet, os; print(os.path.dirname(qrdet.__file__))" | tail -n 1)/.model && pyinstaller -y --add-data "$QRDET_MODEL_DIR:qrdet/.model" --onefile --name ${{ matrix.EXE }} --distpath /files/dist/ /files/src/extract_otp_secrets.py'
+      - name: Check binary size
+        shell: bash
+        run: |
+          MAX_SIZE_MB=900
+          FILE="dist/${{ matrix.EXE }}"
+          SIZE_MB=$(du -m "$FILE" | cut -f1)
+          echo "$FILE size: ${SIZE_MB}MB"
+          if [ "$SIZE_MB" -gt "$MAX_SIZE_MB" ]; then
+            echo "::error::$FILE is ${SIZE_MB}MB, exceeds limit of ${MAX_SIZE_MB}MB"
+            exit 1
+          fi
       - name: Smoke tests linux/amd64
         if: matrix.DOCKER_PLATFORM == 'linux/amd64'
         run: |
@@ -195,13 +218,19 @@ jobs:
         if: matrix.DOCKER_PLATFORM == 'linux/arm64'
         run: |
           docker run --pull always --entrypoint /bin/bash --rm -v "$(pwd)":/files -w /files docker.io/scit0/extract_otp_secrets -c 'dist/${{ matrix.EXE }} -V && dist/${{ matrix.EXE }} -h && dist/${{ matrix.EXE }} example_export.png && dist/${{ matrix.EXE }} - < example_export.txt && dist/${{ matrix.EXE }} --qr ZBAR example_export.png && dist/${{ matrix.EXE }} --qr QREADER example_export.png && dist/${{ matrix.EXE }} --qr QREADER_DEEP example_export.png && dist/${{ matrix.EXE }} --qr CV2 example_export.png && dist/${{ matrix.EXE }} --qr CV2_WECHAT example_export.png'
-      - name: Load Release URL File from release job
+      - name: Load Release Id File from release job
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/download-artifact@v8
         with:
-          name: release_url
+          name: release_id
       - name: Display structure of files
         run: ls -R
+      - name: Set meta data
+        id: meta
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "release_id=$(cat release_id.txt)" >> $GITHUB_OUTPUT
+          echo "upload_url=https://uploads.github.com/repos/scito/extract_otp_secrets/releases/$(cat release_id.txt)/assets?name=" >> $GITHUB_OUTPUT
       - name: Upload EXE to artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -211,7 +240,9 @@ jobs:
         id: upload-release-asset
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          response=$(curl \
+          UPLOAD_FILE="dist/${{ matrix.EXE }}"
+          UPLOAD_NAME="${{ matrix.ASSET_NAME }}"
+          http_status=$(curl \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/x-executable" \
@@ -219,8 +250,15 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --silent \
             --show-error \
-            --data-binary @dist/${{ matrix.EXE }} \
-            $(cat release_url.txt)=${{ matrix.ASSET_NAME }})
+            --output response.json \
+            --write-out "%{http_code}" \
+            --upload-file "$UPLOAD_FILE" "${{ steps.meta.outputs.upload_url }}=$UPLOAD_NAME")
+          echo "HTTP status: $http_status"
+          cat response.json
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "::error::Failed to upload release asset $UPLOAD_NAME (HTTP $http_status)"
+            exit 1
+          fi
 
   build-native-executables:
     name: Build native packages
@@ -288,6 +326,17 @@ jobs:
         if: runner.os == 'Windows'
         run: ls "$($Env:WinDir)\system32"
       - uses: actions/checkout@v5
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
@@ -297,9 +346,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libzbar0
+          sudo apt-get install -y libzbar0 libgl1
       - name: Install zbar shared lib for QReader (macOS)
         if: runner.os == 'macOS'
+        env:
+          # GitHub-hosted macOS runners ship with an untrusted aws/tap, which makes
+          # brew refuse to install anything since Homebrew now requires tap trust.
+          # See https://docs.brew.sh/Tap-Trust
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         run: |
           brew install zbar create-dmg
           # Homebrew on Apple Silicon installs into /opt/homebrew, which is not part of the
@@ -311,18 +365,35 @@ jobs:
         # TODO fix --use-pep517
         run: |
           python -m pip install --upgrade pip
-          pip install -U -r requirements-dev.txt
-          pip install -U .
+          pip install -U -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -U . --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Create Windows win_file_version_info.txt
         shell: bash
         run: |
               mkdir -p build/
               VERSION_STR=$(setuptools-git-versioning) VERSION_MAJOR=$(cut -d '.' -f 1 <<< "$(setuptools-git-versioning)") VERSION_MINOR=$(cut -d '.' -f 2 <<< "$(setuptools-git-versioning)") VERSION_PATCH=$(echo $(cut -d '.' -f 3 <<< "$(setuptools-git-versioning)") | sed -E -n "s/^([0-9]+).*/\1/p") VERSION_BUILD=$(echo $(cut -d '.' -f 3 <<< "$(setuptools-git-versioning)") | sed -E -n -e"s/^[0-9]+.+/99/p")$(($(git rev-list --count $(git tag | sort -V -r | sed '1!d')..HEAD))) COPYRIGHT_YEARS='2020-2025' envsubst < installer/win_file_version_info_template.txt > build/win_file_version_info.txt
+      - name: Install UPX (Windows)
+        # PyInstaller auto-detects upx on PATH and compresses the collected
+        # DLLs/exe with it (no extra pyinstaller flag needed). windows-latest
+        # does not ship upx by default, unlike strip on Linux/macOS.
+        if: runner.os == 'Windows'
+        run: choco install upx -y
       - name: Build with pyinstaller for ${{ matrix.TARGET }}
         env:
           # Reproducible build: https://pyinstaller.org/en/stable/advanced-topics.html#creating-a-reproducible-build
           PYTHONHASHSEED: 31
         run: ${{ matrix.CMD_BUILD }}
+      - name: Check EXE size
+        shell: bash
+        run: |
+          MAX_SIZE_MB=900
+          FILE="dist/${{ matrix.EXE }}"
+          SIZE_MB=$(du -m "$FILE" | cut -f1)
+          echo "$FILE size: ${SIZE_MB}MB"
+          if [ "$SIZE_MB" -gt "$MAX_SIZE_MB" ]; then
+            echo "::error::$FILE is ${SIZE_MB}MB, exceeds limit of ${MAX_SIZE_MB}MB"
+            exit 1
+          fi
       - name: Smoke tests for generated exe (general)
         run: |
           dist/${{ matrix.EXE }} -V
@@ -362,6 +433,18 @@ jobs:
         with:
           name: ${{ matrix.EXE }}
           path: dist/${{ matrix.EXE }}
+      - name: Check DMG size
+        shell: bash
+        if: runner.os == 'macOS'
+        run: |
+          MAX_SIZE_MB=900
+          FILE="dist/${{ matrix.DMG }}"
+          SIZE_MB=$(du -m "$FILE" | cut -f1)
+          echo "$FILE size: ${SIZE_MB}MB"
+          if [ "$SIZE_MB" -gt "$MAX_SIZE_MB" ]; then
+            echo "::error::$FILE is ${SIZE_MB}MB, exceeds limit of ${MAX_SIZE_MB}MB"
+            exit 1
+          fi
       - name: Upload DMG to artifacts
         uses: actions/upload-artifact@v7
         if: runner.os == 'macOS'
@@ -371,13 +454,20 @@ jobs:
       - name: Upload Release Asset
         id: upload-release-asset
         if: matrix.UPLOAD && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: ${{ matrix.ASSET_MIME }}" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --data-binary @dist/${{ matrix.EXE }} ${{ steps.meta.outputs.upload_url }}=${{ matrix.ASSET_NAME }}
+          http_status=$(curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: ${{ matrix.ASSET_MIME }}" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --output response.json --write-out "%{http_code}" --upload-file dist/${{ matrix.EXE }} "${{ steps.meta.outputs.upload_url }}=${{ matrix.ASSET_NAME }}")
+          echo "HTTP status: $http_status"
+          cat response.json
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "::error::Failed to upload release asset ${{ matrix.ASSET_NAME }} (HTTP $http_status)"
+            exit 1
+          fi
       - name: Upload Release Asset DMG (macOS)
         id: upload-release-asset-dmg
         if: false && matrix.UPLOAD && startsWith(github.ref, 'refs/tags/v') && runner.os == 'macOS'
         run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: ${{ matrix.ASSET_MIME }}" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --data-binary @dist/${{ matrix.DMG }} ${{ steps.meta.outputs.upload_url }}=${{ matrix.ASSET_NAME_DMG }}
+          curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: ${{ matrix.ASSET_MIME }}" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --upload-file dist/${{ matrix.DMG }} ${{ steps.meta.outputs.upload_url }}=${{ matrix.ASSET_NAME_DMG }}
 
   upload-hashes:
     name: Upload hashes
@@ -427,7 +517,19 @@ jobs:
                   $asset_url
           done
           (cd assets/ && sha256sum * > ../sha256_hashes.txt)
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: text/plain" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --data-binary @sha256_hashes.txt ${{ steps.meta.outputs.upload_url }}=sha256_hashes.txt
+          http_status=$(curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: text/plain" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --output response.json --write-out "%{http_code}" --data-binary @sha256_hashes.txt "${{ steps.meta.outputs.upload_url }}=sha256_hashes.txt")
+          echo "HTTP status: $http_status"
+          cat response.json
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "::error::Failed to upload sha256_hashes.txt (HTTP $http_status)"
+            exit 1
+          fi
 
           (cd assets/ && sha512sum * > ../sha512_hashes.txt)
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: text/plain" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --data-binary @sha512_hashes.txt ${{ steps.meta.outputs.upload_url }}=sha512_hashes.txt
+          http_status=$(curl -X POST -H "Accept: application/vnd.github+json" -H "Content-Type: text/plain" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --show-error --output response.json --write-out "%{http_code}" --data-binary @sha512_hashes.txt "${{ steps.meta.outputs.upload_url }}=sha512_hashes.txt")
+          echo "HTTP status: $http_status"
+          cat response.json
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "::error::Failed to upload sha512_hashes.txt (HTTP $http_status)"
+            exit 1
+          fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,12 @@
     "search.exclude": {
         "**/build": true,
         "**/dist": true
-      },
+    },
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ],
 }

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 colorama = "0.4.6"
 opencv-contrib-python = "5.0.0.93"
-numpy = "2.5.1"
+numpy = ">=2.4"
 # for macOS: opencv-contrib-python = "<=4.7.0"
 pillow = "*"
 pyzbar = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fc68447491172c59b9016bae923717897c913d7601d76bd73095c2eafb4a7b6f"
+            "sha256": "241ad5e42d244d1426441b873f7b34d32ef4638c554a7b917d759346c7ff7d0e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432",
-                "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
+                "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775",
+                "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.6.17"
+            "version": "==2026.7.22"
         },
         "charset-normalizer": {
             "hashes": [
@@ -1404,11 +1404,11 @@
         },
         "ultralytics": {
             "hashes": [
-                "sha256:5bf553dcbb9853445847bca713e3247894c06120e87fb0a58201901213b436a2",
-                "sha256:bfd423cf74f9be902d4688fd1fbbafac5c7097330a8c1e7e4ced3b45aa633793"
+                "sha256:2625e73863b06dd882b4024b7a3a033ce712d200e3de58af5252939fb74aa403",
+                "sha256:98e15ec09a917f1baacd531a4048ea8c6d54d70162accae51e5b532b573b56b8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==8.4.103"
+            "version": "==8.4.104"
         },
         "ultralytics-thop": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The secrets can be exported to JSON or CSV, or printed as QR codes to console or
 ## Table of contents
 
 - [Table of contents](#table-of-contents)
-- [Download and run binary executable (🆕 since v2.1)](#download-and-run-binary-executable--since-v21)
+- [Download and run binary executable](#download-and-run-binary-executable)
   - [MacOS](#macos)
 - [Usage](#usage)
   - [Capture QR codes from camera (🆕 since version 2.0)](#capture-qr-codes-from-camera--since-version-20)
@@ -90,7 +90,7 @@ The secrets can be exported to JSON or CSV, or printed as QR codes to console or
 - [Third party documentation](#third-party-documentation)
 </details>
 
-## Download and run binary executable (🆕 since v2.1)
+## Download and run binary executable
 
 1. Download executable for your platform from [latest release](https://github.com/scito/extract_otp_secrets/releases/latest), see assets
 2. Linux and macOS: Set executable bit for the downloaded file, e.g in terminal with `chmod +x extract_otp_secrets_X.Y.Z_OS_ARCH`
@@ -328,7 +328,7 @@ python extract_otp_secrets.py = < example_export.png</pre>
 
 * Free and open source
 * Supports Google Authenticator exports (and compatible apps like Aegis Authenticator)
-* Captures the the QR codes directly from the camera using different QR code libraries (based on OpenCV) (🆕 since v2.0)
+* Captures the the QR codes directly from the camera using different QR code libraries (based on OpenCV)
     * ZBAR: [pyzbar](https://github.com/NaturalHistoryMuseum/pyzbar) - fast and reliable, good for images and video capture (default and recommended) [if [libzbar](#installation-of-optional-shared-system-libraries-recommended) is installed]
     * QREADER: [QReader](https://github.com/Eric-Canas/QReader) [if [libzbar](#installation-of-optional-shared-system-libraries-recommended) is installed]
     * QREADER_DEEP: [QReader](https://github.com/Eric-Canas/QReader) - very slow in GUI [if [libzbar](#installation-of-optional-shared-system-libraries-recommended) is installed]
@@ -346,8 +346,8 @@ python extract_otp_secrets.py = < example_export.png</pre>
     * Dedicated CSV for KeePass
     * QR code images
 * Supports reading from stdin and writing to stdout, thus pipes can be used
-* Handles multiple input files (🆕 since v2.0)
-* Reads QR codes images: (See [OpenCV docu](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56)) (🆕 since v2.0)
+* Handles multiple input files
+* Reads QR codes images: (See [OpenCV docu](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56))
     * Portable Network Graphics - *.png
     * WebP - *.webp
     * JPEG files - *.jpeg, *.jpg, *.jpe
@@ -355,16 +355,16 @@ python extract_otp_secrets.py = < example_export.png</pre>
     * Windows bitmaps - *.bmp, *.dib
     * JPEG 2000 files - *.jp2
     * Portable image format - *.pbm, *.pgm, *.ppm *.pxm, *.pnm
-* Prints errors and warnings to stderr (🆕 since v2.0)
-* Prints colored output (🆕 since v2.0)
-* Startable as executable (script, Python, and all dependencies packed in one executable) (🆕 since v2.1)
+* Prints errors and warnings to stderr
+* Prints colored output
+* Startable as executable (script, Python, and all dependencies packed in one executable)
     * extract_otp_secrets_linux_x86_64 (requires glibc >= 2.31)
     * extract_otp_secrets_linux_arm64 (requires glibc >= 2.31)
     * extract_otp_secrets_win_x86_64.exe
     * extract_otp_secrets_macos_arm64 (optional [libzbar](#installation-of-optional-shared-system-libraries-recommended) needs to be installed manually if needed)
         * extract_otp_secrets_macos_arm64.dmg N/A, see [why](#macos)
         * extract_otp_secrets_macos_arm64.pkg N/A, see [why](#macos)
-* Prebuilt Docker images provided for amd64 and arm64 on [Docker Hub](https://hub.docker.com/repository/docker/scit0/extract_otp_secrets) and [GitHub Packages](https://github.com/users/scito/packages/container/package/extract_otp_secrets) (🆕 since v2.0)
+* Prebuilt Docker images provided for amd64 and arm64 on [Docker Hub](https://hub.docker.com/repository/docker/scit0/extract_otp_secrets) and [GitHub Packages](https://github.com/users/scito/packages/container/package/extract_otp_secrets)
 * Many ways to run the script:
     * Native Python
     * pipenv

--- a/build.sh
+++ b/build.sh
@@ -208,6 +208,16 @@ DOCKER="${DOCKER:=docker}"
 PYTHON_VERSION=$($PYTHON --version 2>&1 | cut -d " " -f2 | cut -d "." -f1-2)
 UVENV='.uvenv'
 
+# --extra-index-url for pytorch CPU wheels: only needed on Linux hosts;
+# empty on other OSes so it can be appended unconditionally to pip/uv commands.
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    EXTRA_INDEX_URL="--extra-index-url https://download.pytorch.org/whl/cpu"
+else
+    EXTRA_INDEX_URL=""
+fi
+# Docker builds always run on Linux, so this is always set.
+DOCKER_EXTRA_INDEX_URL="--extra-index-url https://download.pytorch.org/whl/cpu"
+
 # cv2 bundles its own Qt plugins but ships no fonts, which causes
 # "QFontDatabase: Cannot find font directory .../cv2/qt/fonts" warnings as
 # soon as a CV2 window is opened. QT_QPA_FONTDIR is ignored by this Qt build,
@@ -366,7 +376,7 @@ if $build_local; then
 
         $PIP --version
 
-        cmd="$PIP install -U -r requirements.txt"
+        cmd="$PIP install -U -r requirements.txt $EXTRA_INDEX_URL"
         if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
         eval "$cmd"
 
@@ -527,7 +537,7 @@ if $build_local; then
         if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
         eval "$cmd"
         
-        cmd="$UV pip install $VERBOSE -U -r requirements.txt --exclude excludes.txt"
+        cmd="$UV pip install $VERBOSE -U -r requirements.txt $EXTRA_INDEX_URL --exclude excludes.txt"
         if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
         eval "$cmd"
 
@@ -535,7 +545,7 @@ if $build_local; then
         if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
         eval "$cmd"
 
-        cmd="$UV pip install $VERBOSE -U -e . --exclude excludes.txt"
+        cmd="$UV pip install $VERBOSE -U -e . $EXTRA_INDEX_URL --exclude excludes.txt"
         if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
         eval "$cmd"
 
@@ -743,7 +753,7 @@ if $build_docker; then
 
     if $build_exe; then
         if $build_x86_64; then
-            cmd="$DOCKER run --platform linux/amd64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install -U -r /files/requirements.txt && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller -y --specpath installer --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_x86_64_bookworm --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
+            cmd="$DOCKER run --platform linux/amd64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install --no-cache-dir -U -r /files/requirements.txt $DOCKER_EXTRA_INDEX_URL && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller -y --specpath installer --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_x86_64_bookworm --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
             if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
             eval "$cmd"
 
@@ -759,7 +769,7 @@ if $build_docker; then
             BULLSEYE_GLIBC_VERSION=$($DOCKER run --network none --entrypoint /bin/bash --rm extract_otp_secrets:bullseye -c 'ldd --version | sed "1!d" | sed -E "s/.* ([[:digit:]]+\.[[:digit:]]+)$/\1/"')
             echo "Bullseye glibc: $BULLSEYE_GLIBC_VERSION"
 
-            cmd="$DOCKER run --platform linux/amd64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets:bullseye -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install -U -r /files/requirements.txt && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller -y --specpath installer --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_x86_64 --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
+            cmd="$DOCKER run --platform linux/amd64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets:bullseye -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install --no-cache-dir -U -r /files/requirements.txt $DOCKER_EXTRA_INDEX_URL && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller -y --specpath installer --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_x86_64 --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
             if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
             eval "$cmd"
 
@@ -774,7 +784,7 @@ if $build_docker; then
 
         if $build_arm; then
             # build linux/arm64
-            cmd="$DOCKER run --platform linux/arm64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets:bullseye-arm64 -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install -U -r /files/requirements.txt && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller --specpath installer -y --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_arm64 --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
+            cmd="$DOCKER run --platform linux/arm64 --network=host --entrypoint /bin/bash --rm -v \"$($PWD):/files\" -w /files extract_otp_secrets:bullseye-arm64 -c 'apt-get update && apt-get -y install binutils && pip install -U pip && pip install --no-cache-dir -U -r /files/requirements.txt $DOCKER_EXTRA_INDEX_URL && pip install pyinstaller && PYTHONHASHSEED=31 && QRDET_MODEL_DIR=\$(python -c \"import qrdet, os; print(os.path.dirname(qrdet.__file__))\")/.model && pyinstaller --specpath installer -y --add-data \"\$QRDET_MODEL_DIR:qrdet/.model\" --onefile --name extract_otp_secrets_linux_arm64 --distpath /files/dist/ /files/src/extract_otp_secrets.py'"
             if $interactive ; then askContinueYn "$cmd"; else echo -e "${cyan}$cmd${reset}";fi
             eval "$cmd"
 
@@ -866,7 +876,20 @@ if $build_base; then
 fi
 
 line=$(printf '#%.0s' $(eval echo {1..$(( ($COLUMNS - 10) / 2))}))
+
+# Fail the build if any produced artifact in dist/ exceeds the size limit
+MAX_DIST_FILE_SIZE_MB=900
+oversized_files=$(find dist -type f -size +${MAX_DIST_FILE_SIZE_MB}M 2>/dev/null || true)
+if [[ -n "$oversized_files" ]]; then
+    echo -e "\n${redBold}$line FAILED $line${reset}"
+    echo -e "${red}The following file(s) in dist/ exceed ${MAX_DIST_FILE_SIZE_MB}MB:${reset}"
+    ls -Alh $oversized_files
+    exit 1
+fi
+
 echo -e "\n${greenBold}$line SUCCESS $line${reset}"
+
+ls -Alh dist
 
 git status
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN uname -a \
         libzbar0 \
         python3-tk \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -U pip -r requirements.txt \
+    && pip install --no-cache-dir -U pip -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu \
     # Pre-warm QReader/Ultralytics at build time: this downloads the YOLO
     # weights and creates the Ultralytics settings.json once, baking both
     # into the image. Without this, the first QReader() instantiation in

--- a/docs/README_TOC.md
+++ b/docs/README_TOC.md
@@ -3,7 +3,7 @@ Generate from file: README.md
 ## Table of contents
 
 - [Table of contents](#table-of-contents)
-- [Download and run binary executable (🆕 since v2.1)](#download-and-run-binary-executable--since-v21)
+- [Download and run binary executable](#download-and-run-binary-executable)
   - [MacOS](#macos)
 - [Usage](#usage)
   - [Capture QR codes from camera (🆕 since version 2.0)](#capture-qr-codes-from-camera--since-version-20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opencv-contrib-python==5.0.0.93",
   "numpy>=2.2,<2.3 ; python_version >= '3.10' and python_version < '3.11'",
   "numpy>=2.4,<2.5 ; python_version >= '3.11' and python_version < '3.12'",
-  "numpy==2.5.1 ; python_version >= '3.12'",
+  "numpy>=2.4 ; python_version >= '3.12'",
   "Pillow",
   "protobuf==7.35.1",
   "pyzbar",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colorama>=0.4.6
 opencv-contrib-python==5.0.0.93
 numpy>=2.2,<2.3 ; python_version >= "3.10" and python_version < "3.11"
 numpy>=2.4,<2.5 ; python_version >= "3.11" and python_version < "3.12"
-numpy==2.5.1 ; python_version >= "3.12"
+numpy>=2.4 ; python_version >= "3.12"
 Pillow
 protobuf==7.35.1
 pyzbar

--- a/src/extract_otp_secrets.py
+++ b/src/extract_otp_secrets.py
@@ -38,6 +38,7 @@ import csv
 import fileinput
 import glob
 import json
+import logging
 import os
 import platform
 import re
@@ -74,6 +75,13 @@ try:
         import pyzbar.pyzbar as zbar  # type: ignore
         from qreader import QReader
         zbar_available = True
+        # qrdet (a QReader dependency, unmaintained since 2024) still calls
+        # ultralytics' model.predict(half=False, ...), which newer ultralytics
+        # releases log as a deprecation warning ("'half' is deprecated ... Use
+        # 'quantize' instead."). This is harmless (equivalent to quantize=None)
+        # and not something we control, so silence just this one message.
+        logging.getLogger('ultralytics').addFilter(
+            lambda record: "'half' is deprecated" not in record.getMessage())
     except Exception as e:
         if not quiet:
             print(f"""

--- a/uv.lock
+++ b/uv.lock
@@ -12,11 +12,11 @@ resolution-markers = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "numpy", marker = "python_full_version == '3.10.*'", specifier = ">=2.2,<2.3" },
     { name = "numpy", marker = "python_full_version == '3.11.*'", specifier = ">=2.4,<2.5" },
-    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = "==2.5.1" },
+    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=2.4" },
     { name = "opencv-contrib-python", specifier = "==5.0.0.93" },
     { name = "pillow" },
     { name = "protobuf", specifier = "==7.35.1" },
@@ -2056,7 +2056,7 @@ wheels = [
 
 [[package]]
 name = "ultralytics"
-version = "8.4.103"
+version = "8.4.104"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2076,9 +2076,9 @@ dependencies = [
     { name = "torchvision" },
     { name = "ultralytics-thop" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/459f4fd0f337d5e8d479e7196b6c245ff6e703901fa20baa3acd3a8197ba/ultralytics-8.4.103.tar.gz", hash = "sha256:bfd423cf74f9be902d4688fd1fbbafac5c7097330a8c1e7e4ced3b45aa633793", size = 1162044, upload-time = "2026-07-21T02:19:52.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/26/2cc07abfb79b81dac907b88559f732840cabb47c6c92b2fd722a709a1a95/ultralytics-8.4.104.tar.gz", hash = "sha256:98e15ec09a917f1baacd531a4048ea8c6d54d70162accae51e5b532b573b56b8", size = 1191902, upload-time = "2026-07-21T19:42:14.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/7e/c4cdfec674364b906c4e274d96c35a8f534c944f04f2a0fee13f2c9144f8/ultralytics-8.4.103-py3-none-any.whl", hash = "sha256:5bf553dcbb9853445847bca713e3247894c06120e87fb0a58201901213b436a2", size = 1374473, upload-time = "2026-07-21T02:19:47.978Z" },
+    { url = "https://files.pythonhosted.org/packages/64/15/543669b21ab8dc8a882cc872620eef7ed40343d7089ac66a8d448645ed5f/ultralytics-8.4.104-py3-none-any.whl", hash = "sha256:2625e73863b06dd882b4024b7a3a033ce712d200e3de58af5252939fb74aa403", size = 1413385, upload-time = "2026-07-21T19:41:49.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- choose torch cpu (instead of cuda) on linux to ensure small binaries (with cuda sizes are bigger than 2.7GB)
- remove 'new since...' readme info
- remove last tag message in release notes
- fix curl out of memory (use --upload-file instead of --data-binary)
- fix ci: set HOMEBREW_NO_REQUIRE_TAP_TRUST environment variable for macOS Homebrew installation
- feat(ci): add disk space cleanup step for Linux runners
- fix(ci): install libgl1 alongside libzbar0 for smoke tests on Linux
- improve linux asset upload
- fix(ci): install UPX on Windows for PyInstaller builds
- show linux bin size